### PR TITLE
Add DocMenuItem to doc_publish

### DIFF
--- a/projects/docs/BUILD
+++ b/projects/docs/BUILD
@@ -1,4 +1,10 @@
-load("//rules:doc.bzl", "doc_publish")
+load("//rules:doc.bzl", "doc_publish", "doc_menu_item")
+
+doc_menu_item(
+    name = "GitHub",
+    url ="https://github.com/timothyalder/tplat",
+    weight=1000,
+)
 
 doc_publish(
     name = "docs",
@@ -10,6 +16,9 @@ doc_publish(
         "//projects/math/docs",
     ],
     index = "index.md",
+    menu = [
+        ":GitHub",
+    ],
     title = "tplat",
     visibility = ["//visibility:public"],
 )

--- a/rules/detail/doc/_doc_providers.bzl
+++ b/rules/detail/doc/_doc_providers.bzl
@@ -8,3 +8,11 @@ DocSectionInfo = provider(
         "output_dir": "Directory containing built section",
     },
 )
+
+DocMenuItem = provider(
+    fields = {
+        "name": "Name displayed in menu",
+        "url": "URL menu item links to",
+        "weight": "Weight of menu item",
+    }
+)

--- a/rules/detail/doc/_doc_site_args.bzl
+++ b/rules/detail/doc/_doc_site_args.bzl
@@ -1,3 +1,5 @@
+load("//rules/detail/doc:_doc_providers.bzl", "DocMenuItem")
+
 DOC_SITE_ARGS = {
     "title": attr.string(mandatory = True, doc = "Title of generated site"),
     "index": attr.label(
@@ -8,5 +10,10 @@ DOC_SITE_ARGS = {
     "theme": attr.string(
         default = "just-the-docs",
         doc = "Theme to be applied to Jekyll site",
+    ),
+    "menu": attr.label_list(
+        providers = [DocMenuItem],
+        mandatory = False,
+        doc = "DocMenuItems to be used for page menu",
     ),
 }

--- a/rules/detail/doc/doc_menu_item.bzl
+++ b/rules/detail/doc/doc_menu_item.bzl
@@ -12,7 +12,6 @@ def _doc_menu_item_impl(ctx):
 doc_menu_item = rule(
     implementation = _doc_menu_item_impl,
     attrs = {
-        # "name": attr.string(mandatory = True),
         "url": attr.string(mandatory = True),
         "weight": attr.int(default = 0),
     },

--- a/rules/detail/doc/doc_menu_item.bzl
+++ b/rules/detail/doc/doc_menu_item.bzl
@@ -1,0 +1,19 @@
+load("//rules/detail/doc:_doc_providers.bzl", "DocMenuItem")
+
+def _doc_menu_item_impl(ctx):
+    return [
+        DocMenuItem(
+            name = ctx.attr.name,
+            url = ctx.attr.url,
+            weight = ctx.attr.weight,
+        )
+    ]
+
+doc_menu_item = rule(
+    implementation = _doc_menu_item_impl,
+    attrs = {
+        # "name": attr.string(mandatory = True),
+        "url": attr.string(mandatory = True),
+        "weight": attr.int(default = 0),
+    },
+)

--- a/rules/detail/doc/doc_site_build.bzl
+++ b/rules/detail/doc/doc_site_build.bzl
@@ -1,6 +1,7 @@
 load(":_doc_providers.bzl", "DocSectionInfo", "DocSiteInfo")
 load(":_doc_section_args.bzl", "DOC_SECTION_ARGS")
 load(":_doc_site_args.bzl", "DOC_SITE_ARGS")
+load("//rules/detail/doc:_doc_providers.bzl", "DocMenuItem")
 
 def _doc_site_build_impl(ctx):
     section_files = []
@@ -39,8 +40,21 @@ def _doc_site_build_impl(ctx):
             config = config.path,
             theme = ctx.attr.theme,
         ),
+        "echo 'menu:\n  after:' >> '{config}'".format(
+            config = config.path,
+        ),
         "cp '{index}' '{out}/_index.md'".format(index = ctx.file.index.path, out = output_dir.path),
     ]
+    for doc_menu_item in ctx.attr.menu:
+        doc_menu_item = doc_menu_item[DocMenuItem]
+        script_lines.append(
+            "echo '    - name: {name}\n    - url: {url}\n    - weight: {weight}\n' >> '{config}'".format(
+                name = doc_menu_item.name,
+                url = doc_menu_item.url,
+                weight = doc_menu_item.weight,
+                config = config.path,
+            ),
+        )
     for dep in ctx.attr.srcs:
         if DocSectionInfo in dep:
             section = dep[DocSectionInfo].output_dir

--- a/rules/doc.bzl
+++ b/rules/doc.bzl
@@ -1,5 +1,6 @@
 load("//rules/detail/doc:doc_publish.bzl", _doc_publish = "doc_publish")
 load("//rules/detail/doc:doc_section.bzl", _doc_section = "doc_section")
+load("//rules/detail/doc:doc_menu_item.bzl", _doc_menu_item = "doc_menu_item")
 
 def doc_section(**kwargs):
     tags = kwargs.pop("tags", [])
@@ -18,3 +19,5 @@ def doc_publish(**kwargs):
         tags = tags,
         **kwargs
     )
+
+doc_menu_item = _doc_menu_item


### PR DESCRIPTION
Add support for custom menu items by creating a new DocMenuItem provider and adding it to doc_publish attr.